### PR TITLE
Update colorbar based on background color instead of image.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -64,7 +64,7 @@ rules:
   lines-around-directive: error
   max-depth: error
   max-len: 'off'
-  max-lines: error
+  max-lines: warn
   max-nested-callbacks: error
   max-params: error
   max-statements: 'off'
@@ -136,7 +136,7 @@ rules:
   no-process-env: error
   no-process-exit: error
   no-proto: error
-  no-prototype-builtins: error
+  no-prototype-builtins: 'off'
   no-restricted-globals: error
   no-restricted-imports: error
   no-restricted-modules: error
@@ -179,7 +179,7 @@ rules:
   object-curly-newline: error
   object-curly-spacing: error
   object-property-newline: error
-  object-shorthand: error
+  object-shorthand: 'off'
   one-var: 'off'
   one-var-declaration-per-line: 'off'
   operator-assignment:
@@ -189,7 +189,7 @@ rules:
   padded-blocks: 'off'
   prefer-arrow-callback: 'off'
   prefer-const: error
-  prefer-destructuring: error
+  prefer-destructuring: 'off'
   prefer-numeric-literals: error
   prefer-promise-reject-errors: error
   prefer-reflect: 'off'

--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ $('#password').password({
   animateSpeed: 'fast', // the above animation speed
   username: false, // select the username field (selector or jQuery instance) for better password checks
   usernamePartialMatch: true, // whether to check for username partials
-  minimumLength: 4 // minimum password length (below this threshold, the score is 0)
+  minimumLength: 4, // minimum password length (below this threshold, the score is 0)
+  useColorBarImage: false, // use the old colorbar image
+  customColorBarRGB: {
+    red: [0, 240],
+    green: [0, 240],
+    blue: 10
+  } // set custom rgb color ranges for colorbar.
 });
 ~~~
 

--- a/src/password.js
+++ b/src/password.js
@@ -20,7 +20,13 @@
       animateSpeed: 'fast',
       username: false,
       usernamePartialMatch: true,
-      minimumLength: 4
+      minimumLength: 4,
+      useColorBarImage: false,
+      customColorBarRGB: {
+        red: [0, 240],
+        green: [0, 240],
+        blue: 10
+      }
     };
 
     options = $.extend({}, defaults, options);
@@ -166,6 +172,70 @@
     }
 
     /**
+     * Calculates background colors from percentage value.
+     *
+     * @param {int} perc The percentage strength of the password.
+     * @return {object} Object with colors as keys
+     */
+    function calculateColorFromPercentage(perc) {
+      var minRed = 0;
+      var maxRed = 240;
+      var minGreen = 0;
+      var maxGreen = 240;
+      var blue = 10;
+
+      if (options.customColorBarRGB.hasOwnProperty('red')) {
+        minRed = options.customColorBarRGB.red[0];
+        maxRed = options.customColorBarRGB.red[1];
+      }
+
+      if (options.customColorBarRGB.hasOwnProperty('green')) {
+        minGreen = options.customColorBarRGB.green[0];
+        maxGreen = options.customColorBarRGB.green[1];
+      }
+
+      if (options.customColorBarRGB.hasOwnProperty('blue')) {
+        blue = options.customColorBarRGB.blue;
+      }
+
+      var green = (perc * maxGreen / 50);
+      var red = (2 * maxRed) - (perc * maxRed / 50);
+
+      return {
+        red: Math.min(Math.max(red, minRed), maxRed),
+        green: Math.min(Math.max(green, minGreen), maxGreen),
+        blue: blue
+      }
+    }
+
+    /**
+     * Adds color styles to colorbar jQuery object.
+     *
+     * @param {jQuery} $colorbar The colorbar jquery object.
+     * @param {int} perc The percentage strength of the password.
+     * @return {jQuery}
+     */
+    function addColorBarStyle($colorbar, perc) {
+      if (options.useColorBarImage) {
+        $colorbar.css({
+          backgroundPosition: "0px -" + perc + "px",
+          width: perc + '%'
+        });
+      }
+      else {
+        var colors = calculateColorFromPercentage(perc);
+
+        $colorbar.css({
+          'background-image': 'none',
+          'background-color': 'rgb(' + colors.red.toString() + ', ' + colors.green.toString() + ', ' + colors.blue.toString() + ')',
+          width: perc + '%'
+        });
+      }
+
+      return $colorbar;
+    }
+
+    /**
      * Initializes the plugin creating and binding the
      * required layers and events.
      *
@@ -209,10 +279,8 @@
         var score = calculateScore($object.val(), username);
         $object.trigger('password.score', [score]);
         var perc = score < 0 ? 0 : score;
-        $colorbar.css({
-          backgroundPosition: "0px -" + perc + "px",
-          width: perc + '%'
-        });
+
+        $colorbar = addColorBarStyle($colorbar, perc);
 
         if (options.showPercent) {
           $percentage.html(perc + '%');

--- a/test/password.spec.js
+++ b/test/password.spec.js
@@ -188,5 +188,48 @@ describe('$.fn.password', () => {
         .val('_~%8::%nqy^7e~!!z!;N')
         .trigger('keyup')
     })
+
+    it('uses no color background image by default', () => {
+      $('#password').password();
+
+      expect('none').toEqual($('.pass-colorbar').css('background-image'));
+    });
+
+    it('makes background image style adjustments if turned on', (done) => {
+      $('#password').password({useColorBarImage: true}).val('Tester23$').trigger('keyup');
+      $colorbar = $('.pass-colorbar');
+
+      expect('0px -91px').toEqual($colorbar.css('background-position'));
+      expect('91%').toEqual($colorbar.css('width'));
+
+      done();
+    });
+
+    it('can use custom rgb colorbar values for a good password', (done) => {
+      $('#password').password({
+        customColorBarRGB: {
+          green: [0, 100],
+          red: [10, 150],
+          blue: 50
+        }
+      }).val('!Tester23$').trigger('keyup');
+
+      expect('rgb(10, 100, 50)').toEqual($('.pass-colorbar').css('background-color'));
+
+      done();
+    });
+
+    it('can use custom rgb colorbar values for a bad password', (done) => {
+      $('#password').password({
+        customColorBarRGB: {
+          green: [0, 100],
+          red: [10, 150]
+        }
+      }).val('abc').trigger('keyup');
+
+      expect('rgb(150, 0, 10)').toEqual($('.pass-colorbar').css('background-color'));
+
+      done();
+    });
   })
 })


### PR DESCRIPTION
Had to change the eslint file as its checking for es6 features, but also enforcing es5. I'm going to open another ticket to change that.

It also might be best to just remove the image altogether and take out the "useColorImage" property, not sure if that complexity is needed.